### PR TITLE
Finish the categories

### DIFF
--- a/database/src/init.sql
+++ b/database/src/init.sql
@@ -38,5 +38,6 @@ values  ('news', 'generic news articles'),
         ('entertainment', 'to have fun and smile'),
         ('science', 'scientific research articles'),
         ('tech', 'technology, gadgets, and software articles'),
+        ('food', 'food, cooking, and recipes articles'),
         ('sport', 'sport, fitness, and exercise articles');
         

--- a/database/src/init.sql
+++ b/database/src/init.sql
@@ -10,14 +10,14 @@ create table Category (
 );
 create table Article (
         id serial primary key,
-        name varchar(128) null,
-        author varchar(128) not null,
+        name varchar(256) null,
+        author varchar(256) not null,
         category varchar(32) not null references Category(category),
         fake_category varchar(32) not null references Category(category),
         body json not null,
         source_url varchar(256) not null,
         cover_url varchar(256) null,
-        publication_date varchar(24) null, -- I don't like this, should be `Date` or `Timestamptz` type
+        publication_date varchar(32) null, -- I don't like this, should be `Date` or `Timestamptz` type
         retrieved_date timestamptz not null default now()
 );
 

--- a/database/src/init.sql
+++ b/database/src/init.sql
@@ -37,5 +37,6 @@ values  ('news', 'generic news articles'),
         ('opinions', 'peoples opinions on current events'),
         ('entertainment', 'to have fun and smile'),
         ('science', 'scientific research articles'),
+        ('tech', 'technology, gadgets, and software articles'),
         ('sport', 'sport, fitness, and exercise articles');
         

--- a/database/src/init.sql
+++ b/database/src/init.sql
@@ -35,5 +35,7 @@ values  ('news', 'generic news articles'),
         ('weather', 'forecasts, climate'),
         ('travel', 'cultural learnings of other countries'),
         ('opinions', 'peoples opinions on current events'),
+        ('entertainment', 'to have fun and smile'),
+        ('science', 'scientific research articles'),
         ('sport', 'sport, fitness, and exercise articles');
         

--- a/database/src/init.sql
+++ b/database/src/init.sql
@@ -26,10 +26,14 @@ create table Article (
 insert into Category (category, description)
 values  ('news', 'generic news articles'),
         ('gardening', 'gardening, landscaping, or botanical articles'),
-        ('motoring', 'cars or motor sports related articles'),
         ('politics', 'current political events and debate articles'),
         ('business', 'business, fintech, or economic articles'),
         ('culture', 'culturally significant articles'),
         ('world', 'world news and event articles'),
-        ('sport', 'generic sports articles');
+        ('style', 'world fashion'),
+        ('health', 'deceases, new medicines, medical research articles'),
+        ('weather', 'forecasts, climate'),
+        ('travel', 'cultural learnings of other countries'),
+        ('opinions', 'peoples opinions on current events'),
+        ('sport', 'sport, fitness, and exercise articles');
         

--- a/scraper/dev_journal_artem.txt
+++ b/scraper/dev_journal_artem.txt
@@ -30,6 +30,11 @@ I wish it could be a bit more specific so it would be able to
 debug that easier. The list of the errors do not help at all. 
 I love to use scrapy :)
 
+DATE: 17.05.23
+Finished doing the categories for all the spiders in the project. 
+Glad that it is over. That was a terrible experience to debug 
+any error or google how to fix that. Can't wait to start paraphrazing
+
 
 
 

--- a/scraper/dev_journal_artem.txt
+++ b/scraper/dev_journal_artem.txt
@@ -23,6 +23,13 @@ in my if statement. Was a bit painful to run spider after every change so
 I could check if it functions as intended.
 Need to sort out categories for BBC and CNN spiders 
 
+DATE: 13.05.23
+Got every field extracted for BBC spider. Fixed some of the issues. 
+Now it spits a lot of errors that I can't really understand. 
+I wish it could be a bit more specific so it would be able to
+debug that easier. The list of the errors do not help at all. 
+I love to use scrapy :)
+
 
 
 

--- a/scraper/newsscrapper/pipelines.py
+++ b/scraper/newsscrapper/pipelines.py
@@ -26,8 +26,8 @@ class NewsscrapperPipeline:
         articles = json.loads(data)
 
         # For checking purposes if it formats scraped data correctly
-        with open('articles.json', 'w') as f:
-            json.dump(articles, f, indent=4)
+        # with open('articles.json', 'w') as f:
+        #     json.dump(articles, f, indent=4)
 
         try: 
             response = requests.post(

--- a/scraper/newsscrapper/pipelines.py
+++ b/scraper/newsscrapper/pipelines.py
@@ -26,8 +26,8 @@ class NewsscrapperPipeline:
         articles = json.loads(data)
 
         # For checking purposes if it formats scraped data correctly
-        # with open('articles.json', 'w') as f:
-        #     json.dump(articles, f, indent=4)
+        with open('articles.json', 'w') as f:
+            json.dump(articles, f, indent=4)
 
         try: 
             response = requests.post(

--- a/scraper/newsscrapper/spiders/bbc.py
+++ b/scraper/newsscrapper/spiders/bbc.py
@@ -40,12 +40,20 @@ class BbcSpider(scrapy.Spider):
         item['publication_date'] = response.xpath('//time[@data-testid="timestamp"]/@datetime').get()
         item['body'] = response.xpath('//div[contains(@data-component, "text-block")]/div//text()').getall()
 
+        # checks if item['body'] is empty and if it is, then return None
+        if not item['body']:
+            return None
+        
         if response.meta['category'] in ['Asia', 'UK', 'War in Ukraine']:
             response.meta['category'] = 'World'
         elif response.meta['category'] == 'Entertainment & Arts':
             response.meta['category'] = 'Entertainment'
         elif response.meta['category'] == 'Coronavirus':
             response.meta['category'] = 'Health'
+        elif response.meta['category'] == 'Technology':
+            response.meta['category'] = 'tech'
+        elif response.meta['category'] == 'Science & Environment' or response.meta['category'] == 'Climate':
+            response.meta['category'] = 'science'
 
         category = response.meta['category']
         category = category.lower()

--- a/scraper/newsscrapper/spiders/bbc.py
+++ b/scraper/newsscrapper/spiders/bbc.py
@@ -34,7 +34,13 @@ class BbcSpider(scrapy.Spider):
         item['publication_date'] = response.xpath('//time[@data-testid="timestamp"]/@datetime').get()
         item['body'] = response.xpath('//div[contains(@data-component, "text-block")]/div//text()').getall()
 
-        item['category'] = response.xpath('//head/meta[@property="article:section"]/@content').get() or 'News'
+        toFetchCategories = ['us', 'world', 'politics', 'entertainment', 'business', 'science']
+        
+        category = response.xpath('//head/meta[@property="article:section"]/@content').get() or 'News'
+        
+        if category == 'lifestyle':
+
+        item['category'] = category
 
         item['source_url'] = response.url
         item['cover_url'] = response.xpath('//div[@data-component="image-block"]/figure/div/span/picture/img/@src').get()

--- a/scraper/newsscrapper/spiders/bbc.py
+++ b/scraper/newsscrapper/spiders/bbc.py
@@ -3,6 +3,8 @@ from scrapy.spiders import CrawlSpider, Rule
 from scrapy.linkextractors import LinkExtractor
 from scrapy.item import Item, Field
 from newsscrapper.items import Article
+import json
+from urllib.parse import urlparse
 
 #
 #   cd to spiders
@@ -16,23 +18,34 @@ class BbcSpider(scrapy.Spider):
     start_urls = ['https://www.bbc.com/news']
 
     def parse(self, response):
-        for href in response.xpath('//a[contains(@class, "gs-c-promo-heading")]/@href'): 
-            url = response.urljoin(href.extract())
-            yield scrapy.Request(url, callback = self.getArticle)
+        for categories in response.xpath('//ul[@class="gs-o-list-ui--top-no-border nw-c-nav__wide-sections"]//a/@href').getall():
+            url = response.urljoin(str(categories))
+            yield scrapy.Request(url, callback = self.getCategory, meta={'categories': categories})
 
-        #   MOST READ ARTICLES
-        #for href in response.xpath('//div[@class="gs-o-media__body"]/a/@href').getall() : print(href)
+    def getCategory(self, response):
+        for href in response.xpath('//div[@class="mpu-available"]//a/@href').getall():
+            url = response.urljoin(href)
+            yield scrapy.Request(url, callback = self.getArticle)
     
     def getArticle(self, response):
         item = Article()
-        item['name'] = response.xpath('//h1/text()').get()
-        item['author'] = response.xpath('//div[contains(@class, "ssrcss-68pt20-Text-TextContributorName")]/text()').get() or 'bbc'
-        item['publication_date'] = response.xpath('//time[@data-testid="timestamp"]/@datetime').get()
-        item['publication_date'] = response.xpath('//time[@data-testid="timestamp"]/@datetime').get()
+        json_data = response.xpath('//script[contains(text(), "ReportageNewsArticle")]/text()').get()
+        data = json.loads(json_data)
+
+        item['name'] = response.xpath('//head/meta[@property="og:title"]/@content').get()
+
+        author = data['author'][0]['name']
+        item['author'] = author
+
+        publication_date = data['datePublished']
+        item['publication_date'] = publication_date
         item['body'] = response.xpath('//div[contains(@data-component, "text-block")]/div/p[1]/text()').getall()
-        item['category'] = 'news'
+
+        item['category'] = response.xpath('//a[@class="ssrcss-1mu64ez-StyledLink eis6szr2"]//text()').get()
         item['source_url'] = response.url
-        item['cover_url'] = response.xpath('//div[@data-component="image-block"]/figure/div/span/picture/img/@src').get()
+
+        cover_url = data['image']['url']
+        item['cover_url'] = cover_url
 
         # Checks if element text-block exists
         if response.xpath('//div[contains(@data-component, "text-block")]'):
@@ -49,6 +62,3 @@ class BbcSpider(scrapy.Spider):
             item['body'] = response.xpath('//div[@data-reactid=".19qwbyoyauw.0.0.0.1"]/descendant-or-self::*[not(self::script)][normalize-space()]/text()').getall()
 
         yield item
-        
-
-

--- a/scraper/newsscrapper/spiders/bbc.py
+++ b/scraper/newsscrapper/spiders/bbc.py
@@ -32,7 +32,7 @@ class BbcSpider(scrapy.Spider):
         item['author'] = response.xpath('//div[contains(@class, "ssrcss-68pt20-Text-TextContributorName")]/text()').get() or 'bbc'
         item['publication_date'] = response.xpath('//time[@data-testid="timestamp"]/@datetime').get()
         item['publication_date'] = response.xpath('//time[@data-testid="timestamp"]/@datetime').get()
-        item['body'] = response.xpath('//div[contains(@data-component, "text-block")]/div/p[1]/text()').getall()
+        item['body'] = response.xpath('//div[contains(@data-component, "text-block")]/div//text()').getall()
 
         item['category'] = response.xpath('//head/meta[@property="article:section"]/@content').get() or 'News'
 
@@ -41,7 +41,7 @@ class BbcSpider(scrapy.Spider):
 
         # Checks if element text-block exists
         if response.xpath('//div[contains(@data-component, "text-block")]'):
-            item['body'] = response.xpath('//div[contains(@data-component, "text-block")]/div/p/text()').getall()
+            item['body'] = response.xpath('//div[contains(@data-component, "text-block")]/div//text()').getall()
             
         if response.xpath('//div[@class="article__body-content"]'):
             item['author'] = response.xpath('//div[@class="author-unit"]/div/a/text()').get()

--- a/scraper/newsscrapper/spiders/cnn.py
+++ b/scraper/newsscrapper/spiders/cnn.py
@@ -41,6 +41,11 @@ class CNNSpider(scrapy.Spider):
 
         item['category'] = response.xpath('//head/meta[@name="meta-section"]/@content').get()
 
+        if item['category'] == 'cnn-underscored':
+            # do not return item
+            return None
+        
+
         item['source_url'] = response.url
         item['cover_url'] = response.xpath('//head/meta[@property="og:image"]/@content').get()
 

--- a/scraper/newsscrapper/spiders/foxNews.py
+++ b/scraper/newsscrapper/spiders/foxNews.py
@@ -24,7 +24,6 @@ class foxNews(scrapy.Spider):
             url = response.urljoin(str(categories))
             yield scrapy.Request(url, callback = self.getCategory, meta={'categories': categories})
             
-
     def getCategory(self, response):
         for href in response.xpath('//div[@class="m"]/a/@href').getall():
             url = response.urljoin(href)
@@ -39,8 +38,8 @@ class foxNews(scrapy.Spider):
 
         item['publication_date'] = response.xpath('//head/meta[@data-hid="dcterms.created"]/@content').get()
 
-        if response.xpath('//p[@class="dek"]'):
-            item['body'] = response.xpath('//p[@class="dek"]/text()').getall()
+        if response.xpath('//p[@class="speakable"]'):
+            item['body'] = response.xpath('//p[@class="speakable"]//text()').getall()
         else:
             body = response.xpath('//p//text()').getall()
             body = body[10:]
@@ -49,10 +48,20 @@ class foxNews(scrapy.Spider):
             item['body'] = body
             if len(body) == 0:
                 return None
+            
+        toFetchCategories = ['us', 'world', 'politics', 'entertainment', 'business', 'science']
         
         category = response.xpath('//head/meta[@data-hid="prism.section"]/@content').get()
 
-        if category is None:
+        # Reassign category if it's not in the list of categories to fetch
+        if category == 'lifestyle':
+            category = 'entertainment'
+        elif category == 'tech':
+            category = 'science'
+        elif category == 'tv':
+            category = 'entertainment'
+
+        if category is None or category not in toFetchCategories:
             return None
 
         if category == 'fox-news.video':

--- a/scraper/newsscrapper/spiders/foxNews.py
+++ b/scraper/newsscrapper/spiders/foxNews.py
@@ -63,7 +63,8 @@ class foxNews(scrapy.Spider):
 
         if category is None or category not in toFetchCategories:
             return None
-
+        
+        category = category.lower()
         item['category'] = category
 
         item['source_url'] = response.url

--- a/scraper/newsscrapper/spiders/foxNews.py
+++ b/scraper/newsscrapper/spiders/foxNews.py
@@ -64,10 +64,7 @@ class foxNews(scrapy.Spider):
         if category is None or category not in toFetchCategories:
             return None
 
-        if category == 'fox-news.video':
-            item['category'] = 'video'
-        else:
-            item['category'] = category
+        item['category'] = category
 
         item['source_url'] = response.url
 

--- a/scraper/newsscrapper/spiders/newYorkTimes.py
+++ b/scraper/newsscrapper/spiders/newYorkTimes.py
@@ -62,16 +62,28 @@ class newYorkTimesSpider(scrapy.Spider):
         else:
             item['body'] = response.xpath('//section[@name="articleBody"]/div/div//p/text()').getall()
 
-        item['category'] = response.xpath('//head/meta[@name="CG"]/@content').get()
+        category = response.xpath('//head/meta[@name="CG"]/@content').get()
 
-        slug = response.url.split('/')[-3]
-        if slug.isdigit():
-            item["category"] = response.url.split('/')[-2]
-        else:
-            item["category"] = slug
+        toFetchCategories = ['us', 'world', 'politics', 'entertainment', 'business', 'science']
+        entertainmentCategories = ['games', 'books', 'magazine', 'music', 'art']
 
-        if item["category"] == "www.nytimes.com":
-            return
+        # Reassign category if it's not in the list of categories to fetch
+        if category in entertainmentCategories:
+            category = 'entertainment'
+
+        if category == 'dining' or category == 'cooking':
+            category = 'food'
+        elif category == 'tech':
+            category = 'science'
+        elif category == 'sports':
+            category = 'sport'
+        elif category == 'nyregion':
+            category = 'us'
+
+        if category is None or category not in toFetchCategories:
+            return None
+        
+        item["category"] = category
 
         item['source_url'] = response.url
 

--- a/scraper/newsscrapper/spiders/newYorkTimes.py
+++ b/scraper/newsscrapper/spiders/newYorkTimes.py
@@ -64,7 +64,7 @@ class newYorkTimesSpider(scrapy.Spider):
 
         category = response.xpath('//head/meta[@name="CG"]/@content').get()
 
-        toFetchCategories = ['us', 'world', 'politics', 'entertainment', 'business', 'science']
+        toFetchCategories = ['us', 'world', 'politics', 'entertainment', 'business', 'science', 'food', 'style', 'health', 'travel']
         entertainmentCategories = ['games', 'books', 'magazine', 'music', 'art']
 
         # Reassign category if it's not in the list of categories to fetch


### PR DESCRIPTION
# CHANGES:
### Fixed: **_BBC_** & **_CNN_** spiders
*  _**BBC**_ - added categories to the spider. It fetches them all now.
*  _**CNN**_ - added categories to the spider. Fixed some of the fields that were not retrieving data. Time is in `UTC` format

Made spiders to fetch the categories that only exist in the `db`. I also merged some of the categories into big ones so that we would not end up having 100500+ different categories. 

Added some new categories into `db`. Let me know if you are happy about these new categories.

### EXTRA:
Increased the value for the following fields as requested:
* `name` from 128 to 256
* `author` from 128 to 256
* `publication_date`  from 24 to 32

---

### Closed issues: 
* ( #44 )
* ( #33 )
* ( #40 )

---
### **NOTE:** Do we want to keep `food` category?  