### PR TITLE
Scrape and Paraphrase daily

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text elo=lf # All shell scripts must use LF

--- a/api/route/Article/article.create_raw.ts
+++ b/api/route/Article/article.create_raw.ts
@@ -40,12 +40,13 @@ export const create_raw: Route = (req, res) => {
 
     const insertion = format(insertionTemplate, formattedArticles);
     getClient().query<Article>(insertion, [], (err, results) => {
-      console.log(err);
-      if (err)
-        return Error(res, (err as any).code === "23505" ? CONFLICT : INTERNAL_SERVER_ERROR, {
+      if (err) {
+        console.error(err);
+        return Error(res, (err as any).code === '23505' ? CONFLICT : INTERNAL_SERVER_ERROR, {
           message: err.message || 'An unknown error occurred',
           type: 'DatabaseError',
         });
+      }
 
       const { rowCount } = results;
       const message = `inserted ${rowCount} article${rowCount !== 1 ? 's' : ''}`;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
     container_name: scraper
     env_file: ./virtual.env
     build:
-      context: ./scraper
+      context: .
+      dockerfile: ./scraper/Dockerfile
     depends_on:
       - api
 
@@ -39,7 +40,7 @@ services:
       - api
     ports:
       - "${VITE_CLIENT_PORT}:${VITE_CLIENT_PORT}"
-      
+
   search:
     container_name: search
     env_file: ./virtual.env
@@ -55,6 +56,8 @@ services:
     container_name: paraphraser
     env_file: ./virtual.env
     build:
-      context: ./reWriter
+      context: .
+      dockerfile: ./reWriter/Dockerfile
     depends_on:
       - api
+      - scraper

--- a/reWriter/Dockerfile
+++ b/reWriter/Dockerfile
@@ -1,6 +1,18 @@
 FROM python:3.9
 WORKDIR /paraphraser
+
+RUN apt update \
+  && apt install -y cron;
+RUN crontab;
+
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt;
+
 COPY . .
+
+RUN \
+  chmod u+x reWriter.cron.sh; \
+  mv reWriter.cron.sh /etc/cron.d; \
+  crontab /etc/cron.d/reWriter.cron.sh;
+
 ENTRYPOINT ["./init.sh"]

--- a/reWriter/Dockerfile
+++ b/reWriter/Dockerfile
@@ -5,14 +5,23 @@ RUN apt update \
   && apt install -y cron;
 RUN crontab;
 
-COPY requirements.txt .
+COPY reWriter/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt;
 
-COPY . .
+COPY virtual.env /.env
+
+COPY reWriter .
 
 RUN \
   chmod u+x reWriter.cron.sh; \
-  mv reWriter.cron.sh /etc/cron.d; \
-  crontab /etc/cron.d/reWriter.cron.sh;
+  cat /.env > .temp; \
+  cat reWriter.cron.sh >> .temp; \
+  mv .temp reWriter.cron.sh; \
+  mv reWriter.cron.sh /etc/cron.d/reWriter.cron.sh; \
+  crontab /etc/cron.d/reWriter.cron.sh; \
+  touch /var/log/cron.log;
 
-ENTRYPOINT ["./init.sh"]
+CMD \
+  ./init.sh && \
+  cron && \
+  tail -f /var/log/cron.log;

--- a/reWriter/reWriter.cron.sh
+++ b/reWriter/reWriter.cron.sh
@@ -1,0 +1,1 @@
+30 12 * * * python /reWriter/reWriter.py # Run paraphraser every day at 12:30

--- a/reWriter/reWriter.cron.sh
+++ b/reWriter/reWriter.cron.sh
@@ -1,1 +1,4 @@
-30 12 * * * python /reWriter/reWriter.py # Run paraphraser every day at 12:30
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+30 0 * * * cd /reWriter && python ./reWriter.py >> /var/log/cron.log 2>&1 # Run paraphraser at 00:30 every day ( scraper should be done by then )

--- a/scraper/Dockerfile
+++ b/scraper/Dockerfile
@@ -3,20 +3,24 @@ WORKDIR /scraper
 
 RUN apt update \
   && apt install -y cron;
-RUN crontab;
 
-COPY requirements.txt .
+COPY scraper/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt;
 
-COPY . .
+COPY virtual.env /.env
+
+COPY scraper/ .
 
 RUN \
   chmod u+x scrape.cron.sh; \
+  cat /.env > .temp; \
+  cat scrape.cron.sh >> .temp; \
+  mv .temp scrape.cron.sh; \
   mv scrape.cron.sh /etc/cron.d/scrape.cron.sh; \
   crontab /etc/cron.d/scrape.cron.sh; \
-  touch /var/log/cron.log
+  touch /var/log/cron.log;
 
-CMD cron && \
-  tail -f /var/log/cron.log
-
-# ENTRYPOINT ["./runspiders.sh"]
+CMD \
+  ./runspiders.sh && \
+  cron && \
+  tail -f /var/log/cron.log;

--- a/scraper/Dockerfile
+++ b/scraper/Dockerfile
@@ -1,6 +1,22 @@
 FROM python:3.9
 WORKDIR /scraper
+
+RUN apt update \
+  && apt install -y cron;
+RUN crontab;
+
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt;
+
 COPY . .
-ENTRYPOINT ["./runspiders.sh"]
+
+RUN \
+  chmod u+x scrape.cron.sh; \
+  mv scrape.cron.sh /etc/cron.d/scrape.cron.sh; \
+  crontab /etc/cron.d/scrape.cron.sh; \
+  touch /var/log/cron.log
+
+CMD cron && \
+  tail -f /var/log/cron.log
+
+# ENTRYPOINT ["./runspiders.sh"]

--- a/scraper/scrape.cron.sh
+++ b/scraper/scrape.cron.sh
@@ -1,1 +1,4 @@
-* * * * * /scraper/runspiders.sh >> var/log/cron.log 2>&1 # Run scraper every minute
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+0 0 * * * cd /scraper && ./runspiders.sh >> /var/log/cron.log 2>&1 # Run scraper daily at midnight
+

--- a/scraper/scrape.cron.sh
+++ b/scraper/scrape.cron.sh
@@ -1,0 +1,1 @@
+* * * * * /scraper/runspiders.sh >> var/log/cron.log 2>&1 # Run scraper every minute

--- a/scraper/scrape.cron.sh
+++ b/scraper/scrape.cron.sh
@@ -1,4 +1,4 @@
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-0 0 * * * cd /scraper && ./runspiders.sh >> /var/log/cron.log 2>&1 # Run scraper daily at midnight
 
+0 0 * * * cd /scraper && ./runspiders.sh >> /var/log/cron.log 2>&1 # Run scraper daily at midnight


### PR DESCRIPTION
The `Scraper` and `Paraphraser` modules have been configured to run within the Docker containers using [`Cron`](https://en.wikipedia.org/wiki/Cron).

- *Scraper* runs at [`0 0 * * *`](https://crontab.guru/#0_0_*_*_*). Midnight seems a good time.

- *Paraphraser* runs at [`30 0 * * *`](https://crontab.guru/#30_0_*_*_*). This gives the scraper a good amount of headroom. Though it's usually done within 4-5 minutes.

For a future sprint (sooner rather than later, I think) We should do backups at a time like [`0 6 * * *`](https://crontab.guru/#0_6_*_*_*). 

I've redirected *stdout* and *stderr* to a log file which is `tail`ed so you can see whats going on in the cron environment.

**Please ensure the scripts and environment variable files (`virtual.env`) use `LF` not `CRLF` when testing this branch. Cron errors are often silent.**

> The modules still run on startup so your not waiting around for midnight 😉.

closes #78 

